### PR TITLE
ED runs and writes the output files.

### DIFF
--- a/ED/src/io/h5_output.F90
+++ b/ED/src/io/h5_output.F90
@@ -735,6 +735,7 @@ subroutine h5_output(vtype)
                              ,', as it doesn''t belong to this file...'
             end if
          end do varloop
+	 call h5fflush_f(file_id,H5F_SCOPE_LOCAL_F, hdferr)
          !---------------------------------------------------------------------------------!
 
          if (verbose) write (unit=*,fmt='(a)') '    > Closing file...'


### PR DESCRIPTION
The problem with output files was because of new GCC compilers and HDF5. Thanks Ryan Knox for pointing this out.
